### PR TITLE
Traffic server fixes

### DIFF
--- a/local/include/core/HttpReplay.h
+++ b/local/include/core/HttpReplay.h
@@ -173,6 +173,8 @@ protected:
     CR,   ///< Expecting the size terminating CR
     LF,   ///< Expecting the size terminating LF.
     BODY, ///< Inside the chunk body.
+    POST_BODY_CR,
+    POST_BODY_LF,
     FINAL ///< Terminating (size zero) chunk parsed.
   } _state = State::INIT;
 };
@@ -270,7 +272,7 @@ public:
   swoc::Rv<ParseResult> parse_request(TextView data);
   swoc::Rv<ParseResult> parse_response(TextView data);
 
-  swoc::Errata update_content_length();
+  swoc::Errata update_content_length(TextView method);
   swoc::Errata update_transfer_encoding();
 
   std::string make_key();
@@ -429,5 +431,5 @@ protected:
   std::deque<ThreadInfo *> _threadPool;
   std::condition_variable _threadPoolCvar;
   std::mutex _threadPoolMutex;
-  const int max_threads = 100;
+  const int max_threads = 2000;
 };

--- a/local/include/core/HttpReplay.h
+++ b/local/include/core/HttpReplay.h
@@ -63,7 +63,7 @@ static const std::string YAML_HTTP_URL_KEY{"url"};
 static const std::string YAML_CONTENT_KEY{"content"};
 static const std::string YAML_CONTENT_LENGTH_KEY{"size"};
 
-static constexpr size_t MAX_HDR_SIZE = 65536;
+static constexpr size_t MAX_HDR_SIZE = 131072;	// Max our ATS is configured for
 static constexpr size_t MAX_DRAIN_BUFFER_SIZE = 1 << 20;
 /// HTTP end of line.
 static constexpr swoc::TextView HTTP_EOL{"\r\n"};

--- a/local/src/core/HttpReplay.cc
+++ b/local/src/core/HttpReplay.cc
@@ -862,6 +862,20 @@ swoc::Errata Load_Replay_File(swoc::file::path const &path,
                               result.note(handler.txn_close());
                             }
                             errata = std::move(result);
+                          // Deal with the cached case
+                          } else if (txn_node[YAML_CLIENT_REQ_KEY] && txn_node[YAML_PROXY_RSP_KEY]) {
+                            result.note(handler.txn_open(txn_node));
+                            if (result.is_ok()) {
+                              result.note(handler.client_request(
+                                  txn_node[YAML_CLIENT_REQ_KEY]));
+                              result.note(handler.proxy_request(
+                                  txn_node[YAML_CLIENT_REQ_KEY]));
+                              result.note(handler.proxy_response(
+                                  txn_node[YAML_PROXY_RSP_KEY]));
+                              result.note(handler.server_response(
+                                  txn_node[YAML_PROXY_RSP_KEY]));
+                              result.note(handler.txn_close());
+                            }
                           } else {
                             errata.error(
                                 R"(Transaction node at {} in "{}" did not contain all four required HTTP header keys.)",

--- a/local/src/server/replay-server.cc
+++ b/local/src/server/replay-server.cc
@@ -177,7 +177,7 @@ void TF_Serve(std::thread *t) {
           auto spot{Transactions.find(key)};
           if (spot != Transactions.end()) {
             [[maybe_unused]] auto const &[key, txn] = *spot;
-            req_hdr.update_content_length();
+            req_hdr.update_content_length(req_hdr._method);
             req_hdr.update_transfer_encoding();
             if (req_hdr._content_length_p || req_hdr._chunked_p) {
               Info("Draining request body.");
@@ -410,8 +410,8 @@ int main(int argc, const char *argv[]) {
   engine.parser
       .add_command("run", "run <dir>: the replay server using data in <dir>",
                    "", 1, [&]() -> void { engine.command_run(); })
-      .add_option("--listen", "", "Listen address and port", "", 1, "")
-      .add_option("--listen-https", "", "Listen TLS address and port", "", 1,
+      .add_option("--listen", "", "Listen address and port. Can be a comma separated list.", "", 1, "")
+      .add_option("--listen-https", "", "Listen TLS address and port. Can be a comma separated list.", "", 1,
                   "")
       .add_option("--cert", "", "Specify certificate file", "", 1, "");
 


### PR DESCRIPTION
Fixes discovered while working a real data set from replay-client->ATS->replay-server

* Fix chunked encoding processing
* Handle 100-continue
* Have HEAD method ignore content-length header.