### PR TITLE
Various tweaks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,13 @@
 *.out
 *.app
 
+/include
+/bin
+/lib/cmake
+/lib/pkgconfig
+/lib64
+/cmake-build-release
+
 # Default parts directories
 \.parts\.cache
 \_*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,14 @@ cmake_minimum_required(VERSION 3.12)
 set(CMAKE_CXX_STANDARD 17)
 
 set(INSTALL_DIR ${CMAKE_HOME_DIRECTORY})
+set(CMAKE_PREFIX_PATH ${CMAKE_HOME_DIRECTORY})
 if(NOT DEFINED CMAKE_PREFIX_PATH)
     set(CMAKE_PREFIX_PATH ${INSTALL_DIR})
 endif()
+set(CMAKE_INSTALL_BINDIR ${CMAKE_PREFIX_PATH}/bin)
+set(CMAKE_INSTALL_LIBDIR ${CMAKE_PREFIX_PATH}/lib)
 
 include(ExternalProject)
-set(EP_BASE extern)
 
 # All of the arguments to pass to external projects.
 set(_CMAKE_ARGS
@@ -37,19 +39,11 @@ ExternalProject_Add(lib-yaml-cpp
 
 ExternalProject_Add(lib-swoc++
     GIT_REPOSITORY https://github.com/solidwallofcode/libswoc.git
-    GIT_TAG replay
+    GIT_TAG 1.0.6
     GIT_SHALLOW TRUE
     SOURCE_SUBDIR swoc++
     INSTALL_DIR ${INSTALL_DIR}
     CMAKE_ARGS "${_CMAKE_ARGS}"
-    STEP_TARGETS install
-    )
-
-ExternalProject_Add(local
-    SOURCE_DIR ${CMAKE_HOME_DIRECTORY}/local
-    INSTALL_DIR ${INSTALL_DIR}
-    CMAKE_ARGS "${_CMAKE_ARGS}"
-    DEPENDS lib-yaml-cpp-install lib-swoc++-install
     STEP_TARGETS install
     )
 

--- a/local/include/core/HttpReplay.h
+++ b/local/include/core/HttpReplay.h
@@ -63,7 +63,7 @@ static const std::string YAML_HTTP_URL_KEY{"url"};
 static const std::string YAML_CONTENT_KEY{"content"};
 static const std::string YAML_CONTENT_LENGTH_KEY{"size"};
 
-static constexpr size_t MAX_HDR_SIZE = 131072;	// Max our ATS is configured for
+static constexpr size_t MAX_HDR_SIZE = 131072; // Max our ATS is configured for
 static constexpr size_t MAX_DRAIN_BUFFER_SIZE = 1 << 20;
 /// HTTP end of line.
 static constexpr swoc::TextView HTTP_EOL{"\r\n"};

--- a/local/include/core/HttpReplay.h
+++ b/local/include/core/HttpReplay.h
@@ -348,13 +348,25 @@ inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec,
 }
 } // namespace swoc
 
+/** Protocol class for loading a replay file.
+ * The client and server are expected subclass this an provide an implementation.
+ */
 class ReplayFileHandler {
 public:
   virtual swoc::Errata file_open(swoc::file::path const &path) { return {}; }
   virtual swoc::Errata file_close() { return {}; }
   virtual swoc::Errata ssn_open(YAML::Node const &node) { return {}; }
   virtual swoc::Errata ssn_close() { return {}; }
+
+  /** Open the transaction node.
+   *
+   * @param node Transaction node.
+   * @return Errors, if any.
+   *
+   * This is required to do any base validation of the transaction such as verifying required keys.
+   */
   virtual swoc::Errata txn_open(YAML::Node const &node) { return {}; }
+
   virtual swoc::Errata txn_close() { return {}; }
   virtual swoc::Errata client_request(YAML::Node const &node) { return {}; }
   virtual swoc::Errata proxy_request(YAML::Node const &node) { return {}; }
@@ -380,19 +392,6 @@ inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec,
   return bwformat(w, spec, path.string());
 }
 } // namespace swoc
-
-namespace std {
-template <typename R>
-class tuple_size<swoc::Rv<R>> : public std::integral_constant<size_t, 2> {};
-template <typename R> class tuple_element<0, swoc::Rv<R>> {
-public:
-  using type = R;
-};
-template <typename R> class tuple_element<1, swoc::Rv<R>> {
-public:
-  using type = swoc::Errata;
-};
-} // namespace std
 
 template <typename... Args> void Info(swoc::TextView fmt, Args &&... args) {
   if (Verbose) {

--- a/local/include/core/HttpReplay.h
+++ b/local/include/core/HttpReplay.h
@@ -349,7 +349,8 @@ inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec,
 } // namespace swoc
 
 /** Protocol class for loading a replay file.
- * The client and server are expected subclass this an provide an implementation.
+ * The client and server are expected subclass this an provide an
+ * implementation.
  */
 class ReplayFileHandler {
 public:
@@ -363,7 +364,8 @@ public:
    * @param node Transaction node.
    * @return Errors, if any.
    *
-   * This is required to do any base validation of the transaction such as verifying required keys.
+   * This is required to do any base validation of the transaction such as
+   * verifying required keys.
    */
   virtual swoc::Errata txn_open(YAML::Node const &node) { return {}; }
 

--- a/local/src/client/CMakeLists.txt
+++ b/local/src/client/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(replay-client
     replay-client.cc
 )
 
-target_link_libraries(replay-client PUBLIC lib-replay-core swoc++::swoc++ yaml-cpp Threads::Threads OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(replay-client PUBLIC replay-core swoc++::swoc++ yaml-cpp Threads::Threads OpenSSL::SSL OpenSSL::Crypto)
 
 install(TARGETS replay-client
     EXPORT replay-client-config

--- a/local/src/client/replay-client.cc
+++ b/local/src/client/replay-client.cc
@@ -25,6 +25,7 @@ inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec,
 } // namespace swoc
 
 using swoc::TextView;
+using swoc::Errata;
 
 struct Txn {
   HttpHeader _req; ///< Request to send.
@@ -147,7 +148,17 @@ swoc::Errata ClientReplayFileHandler::ssn_open(YAML::Node const &node) {
   return errata;
 }
 
-swoc::Errata ClientReplayFileHandler::txn_open(YAML::Node const &) {
+swoc::Errata ClientReplayFileHandler::txn_open(YAML::Node const &node) {
+  Errata errata;
+  if (! node[YAML_CLIENT_REQ_KEY]) {
+    errata.error(R"(Transaction node at {} does not have a client request [{}].)", node.Mark(), YAML_CLIENT_REQ_KEY);
+  }
+  if (! node[YAML_PROXY_RSP_KEY]) {
+    errata.error(R"(Transaction node at {} does not have a proxy response [{}].)", node.Mark(), YAML_PROXY_RSP_KEY);
+  }
+  if (! errata.is_ok()) {
+    return {std::move(errata)};
+  }
   LoadMutex.lock();
   return {};
 }

--- a/local/src/client/replay-client.cc
+++ b/local/src/client/replay-client.cc
@@ -24,8 +24,8 @@ inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec,
 }
 } // namespace swoc
 
-using swoc::TextView;
 using swoc::Errata;
+using swoc::TextView;
 
 struct Txn {
   HttpHeader _req; ///< Request to send.
@@ -150,13 +150,17 @@ swoc::Errata ClientReplayFileHandler::ssn_open(YAML::Node const &node) {
 
 swoc::Errata ClientReplayFileHandler::txn_open(YAML::Node const &node) {
   Errata errata;
-  if (! node[YAML_CLIENT_REQ_KEY]) {
-    errata.error(R"(Transaction node at {} does not have a client request [{}].)", node.Mark(), YAML_CLIENT_REQ_KEY);
+  if (!node[YAML_CLIENT_REQ_KEY]) {
+    errata.error(
+        R"(Transaction node at {} does not have a client request [{}].)",
+        node.Mark(), YAML_CLIENT_REQ_KEY);
   }
-  if (! node[YAML_PROXY_RSP_KEY]) {
-    errata.error(R"(Transaction node at {} does not have a proxy response [{}].)", node.Mark(), YAML_PROXY_RSP_KEY);
+  if (!node[YAML_PROXY_RSP_KEY]) {
+    errata.error(
+        R"(Transaction node at {} does not have a proxy response [{}].)",
+        node.Mark(), YAML_PROXY_RSP_KEY);
   }
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     return {std::move(errata)};
   }
   LoadMutex.lock();

--- a/local/src/core/CMakeLists.txt
+++ b/local/src/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(lib-replay-core)
+project(replay-core)
 set(CMAKE_CXX_STANDARD 17)
 include(GNUInstallDirs)
 
@@ -8,21 +8,21 @@ include(GNUInstallDirs)
 find_package(swoc++ CONFIG REQUIRED)
 find_package(OpenSSL REQUIRED)
 
-add_library(lib-replay-core STATIC
+add_library(replay-core STATIC
     ArgParser.cc
     HttpReplay.cc
 )
 
-target_include_directories(lib-replay-core PUBLIC)
-target_link_libraries(lib-replay-core PUBLIC swoc++::swoc++)
-#target_include_directories(lib-replay-core swoc::swoc)
+target_include_directories(replay-core PUBLIC)
+target_link_libraries(replay-core PUBLIC swoc++::swoc++)
 
-install(TARGETS lib-replay-core
-    EXPORT lib-replay-core-config
+install(TARGETS replay-core ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS replay-core
+    EXPORT replay-core-config
     ARCHIVE DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
-install(EXPORT lib-replay-core-config
+install(EXPORT replay-core-config
     NAMESPACE replay-core::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/replay-core
     )
-export(TARGETS lib-replay-core FILE lib-replay-core-config.cmake)
+export(TARGETS replay-core FILE replay-core-config.cmake)

--- a/local/src/core/HttpReplay.cc
+++ b/local/src/core/HttpReplay.cc
@@ -856,16 +856,20 @@ swoc::Errata Load_Replay_File(swoc::file::path const &path,
                         for (auto const &txn_node : txn_list_node) {
                           result = handler.txn_open(txn_node);
                           if (result.is_ok()) {
-                            if (auto creq_node{txn_node[YAML_CLIENT_REQ_KEY]}; creq_node) {
+                            if (auto creq_node{txn_node[YAML_CLIENT_REQ_KEY]};
+                                creq_node) {
                               result.note(handler.client_request(creq_node));
                             }
-                            if (auto preq_node{txn_node[YAML_PROXY_REQ_KEY]}; preq_node) {
+                            if (auto preq_node{txn_node[YAML_PROXY_REQ_KEY]};
+                                preq_node) {
                               result.note(handler.proxy_request(preq_node));
                             }
-                            if (auto ursp_node{txn_node[YAML_SERVER_RSP_KEY]}; ursp_node) {
+                            if (auto ursp_node{txn_node[YAML_SERVER_RSP_KEY]};
+                                ursp_node) {
                               result.note(handler.server_response(ursp_node));
                             }
-                            if (auto prsp_node{txn_node[YAML_PROXY_RSP_KEY]}; prsp_node) {
+                            if (auto prsp_node{txn_node[YAML_PROXY_RSP_KEY]};
+                                prsp_node) {
                               result.note(handler.proxy_response(prsp_node));
                             }
                             result.note(handler.txn_close());
@@ -917,24 +921,26 @@ Load_Replay_Directory(swoc::file::path const &path,
 
   dirent **elements = nullptr;
 
-  auto stat { swoc::file::status(path, ec) };
+  auto stat{swoc::file::status(path, ec)};
   if (ec) {
     return Errata().error(R"(Invalid test directory "{}" - [{}])", path, ec);
   } else if (swoc::file::is_regular_file(stat)) {
     return loader(path);
-  } else if (! swoc::file::is_dir(stat)) {
+  } else if (!swoc::file::is_dir(stat)) {
     return Errata().error(R"("{}" is not a file or a directory.)", path);
   }
 
   if (0 == chdir(path.c_str())) {
-    int n_sessions =
-        scandir(".", &elements,
-                [](const dirent *entry) -> int {
-          auto extension = swoc::TextView{entry->d_name, strlen(entry->d_name)}.suffix_at('.');
+    int n_sessions = scandir(
+        ".", &elements,
+        [](const dirent *entry) -> int {
+          auto extension =
+              swoc::TextView{entry->d_name, strlen(entry->d_name)}.suffix_at(
+                  '.');
           return 0 == strcasecmp(extension, "json") ||
                  0 == strcasecmp(extension, "yaml");
-                },
-                &alphasort);
+        },
+        &alphasort);
     if (n_sessions > 0) {
       std::atomic<int> idx{0};
       swoc::MemSpan<dirent *> entries{elements,

--- a/local/src/core/HttpReplay.cc
+++ b/local/src/core/HttpReplay.cc
@@ -35,6 +35,8 @@
 #include "swoc/bwf_std.h"
 
 using swoc::Errata;
+using swoc::TextView;
+using namespace swoc::literals;
 
 bool Verbose = false;
 
@@ -740,10 +742,9 @@ HttpHeader::parse_request(swoc::TextView data) {
 
     auto first_line{data.take_prefix_at('\n')};
     if (first_line) {
-      if (first_line.suffix(1)[0] == '\r') {
-        first_line.remove_suffix(1);
-      }
-      _method = this->localize(first_line.prefix_if(&isspace));
+      first_line.remove_suffix_if(&isspace);
+      _method = this->localize(first_line.take_prefix_if(&isspace));
+      _url = this->localize(first_line.ltrim_if(&isspace).take_prefix_if(&isspace));
 
       while (data) {
         auto field{data.take_prefix_at('\n').rtrim_if(&isspace)};
@@ -819,6 +820,8 @@ operator()(BufferWriter &w, const swoc::bwf::Spec &spec) const {
     } else {
       bwformat(w, spec, "*N/A*");
     }
+  } else if (0 == strcasecmp("url"_tv, name)) {
+    bwformat(w, spec, _hdr._url);
   } else {
     bwformat(w, spec, "*N/A*");
   }

--- a/local/src/core/HttpReplay.cc
+++ b/local/src/core/HttpReplay.cc
@@ -307,7 +307,8 @@ ChunkCodex::transmit(Stream &stream, swoc::TextView data, size_t chunk_size) {
       if (n > 0) {
         total += n;
         if (n == chunk_size) {
-          w.clear().print("{}", HTTP_EOL); // Each chunk much terminate with CRLF
+          w.clear().print("{}",
+                          HTTP_EOL); // Each chunk much terminate with CRLF
           stream.write(w.view());
           data.remove_prefix(chunk_size);
         } else {
@@ -359,8 +360,8 @@ swoc::Errata HttpHeader::update_content_length(swoc::TextView method) {
     if (auto spot{_fields.find(FIELD_CONTENT_LENGTH)}; spot != _fields.end()) {
       cl = swoc::svtou(spot->second);
       if (_content_size != 0 && cl != _content_size) {
-        errata.info(R"(Conflicting sizes using "{}" value {} instead of {}.)", cl,
-                    _content_size);
+        errata.info(R"(Conflicting sizes using "{}" value {} instead of {}.)",
+                    cl, _content_size);
       }
       _content_size = cl;
       _content_length_p = true;
@@ -409,8 +410,8 @@ swoc::Errata HttpHeader::transmit_body(Stream &stream) const {
   } else if (!_content_size && _status && !STATUS_NO_CONTENT[_status]) {
     // Go ahead and close the connection if it is not specified
     if (!_chunked_p && !_content_length_p) {
-        Info("No CL or TE, status {} - closing.", _status);
-        stream.close();
+      Info("No CL or TE, status {} - closing.", _status);
+      stream.close();
     }
   }
 
@@ -473,15 +474,17 @@ swoc::Errata HttpHeader::drain_body(Stream &stream,
   }
 
   // If there's a status, and it indicates no body, we're done.
-  if (_status && STATUS_NO_CONTENT[_status] && !_content_length_p && !_chunked_p) {
+  if (_status && STATUS_NO_CONTENT[_status] && !_content_length_p &&
+      !_chunked_p) {
     return errata;
   }
 
   buff.reserve(std::min<size_t>(content_length, MAX_DRAIN_BUFFER_SIZE));
 
   if (stream.is_closed()) {
-    errata.error(R"(drain_body: stream closed) could not read {} bytes)", content_length);
-    return errata; 
+    errata.error(R"(drain_body: stream closed) could not read {} bytes)",
+                 content_length);
+    return errata;
   }
 
   if (_chunked_p) {
@@ -518,7 +521,7 @@ swoc::Errata HttpHeader::drain_body(Stream &stream,
       errata.error(R"(Invalid response - expected {} bytes, drained {} byts.)",
                    content_length, body_size);
       return errata;
-    } 
+    }
     Info("Drained {} chunked bytes.", body_size);
   } else {
     body_size = initial.size();
@@ -538,8 +541,9 @@ swoc::Errata HttpHeader::drain_body(Stream &stream,
       body_size += n;
     }
     if (body_size > content_length) {
-      errata.error(R"(Invalid response - expected {} fixed bytes, drained {} byts.)",
-                   content_length, body_size);
+      errata.error(
+          R"(Invalid response - expected {} fixed bytes, drained {} byts.)",
+          content_length, body_size);
       return errata;
     }
     Info("Drained {} bytes.", body_size);
@@ -591,7 +595,7 @@ swoc::Rv<ssize_t> HttpHeader::read_header(Stream &reader,
         zret.errata().error(
             R"(Connection closed unexpectedly after {} bytes while waiting for header - {}.)",
             w.size(), swoc::bwf::Errno{});
-         printf("error\n");
+        printf("error\n");
       } else {
         zret = 0; // clean close between transactions.
       }
@@ -865,8 +869,9 @@ swoc::Errata Load_Replay_File(swoc::file::path const &path,
                               result.note(handler.txn_close());
                             }
                             errata = std::move(result);
-                          // Deal with the cached case
-                          } else if (txn_node[YAML_CLIENT_REQ_KEY] && txn_node[YAML_PROXY_RSP_KEY]) {
+                            // Deal with the cached case
+                          } else if (txn_node[YAML_CLIENT_REQ_KEY] &&
+                                     txn_node[YAML_PROXY_RSP_KEY]) {
                             result.note(handler.txn_open(txn_node));
                             if (result.is_ok()) {
                               result.note(handler.client_request(
@@ -935,12 +940,9 @@ Load_Replay_Directory(swoc::file::path const &path,
     int n_sessions =
         scandir(".", &elements,
                 [](const dirent *entry) -> int {
-                  return 0 == strcasecmp(swoc::TextView{entry->d_name,
-                                                        strlen(entry->d_name)}
-                                             .suffix_at('.'),
-                                         "json")
-                             ? 1
-                             : 0;
+          auto extension = swoc::TextView{entry->d_name, strlen(entry->d_name)}.suffix_at('.');
+          return 0 == strcasecmp(extension, "json") ||
+                 0 == strcasecmp(extension, "yaml");
                 },
                 &alphasort);
     if (n_sessions > 0) {
@@ -977,8 +979,7 @@ Load_Replay_Directory(swoc::file::path const &path,
   return errata;
 }
 
-swoc::Errata parse_ips(std::string arg, std::deque<swoc::IPEndpoint> &target)
-{
+swoc::Errata parse_ips(std::string arg, std::deque<swoc::IPEndpoint> &target) {
   swoc::Errata errata;
   int offset = 0;
   int new_offset;
@@ -992,12 +993,12 @@ swoc::Errata parse_ips(std::string arg, std::deque<swoc::IPEndpoint> &target)
       return errata;
     }
     target.push_back(addr);
-  } 
+  }
   return errata;
 }
 
-swoc::Errata resolve_ips(std::string arg, std::deque<swoc::IPEndpoint> &target)
-{
+swoc::Errata resolve_ips(std::string arg,
+                         std::deque<swoc::IPEndpoint> &target) {
   swoc::Errata errata;
   int offset = 0;
   int new_offset;
@@ -1011,7 +1012,7 @@ swoc::Errata resolve_ips(std::string arg, std::deque<swoc::IPEndpoint> &target)
       return errata;
     }
     target.push_back(tmp_target);
-  } 
+  }
   return errata;
 }
 

--- a/local/src/server/CMakeLists.txt
+++ b/local/src/server/CMakeLists.txt
@@ -15,14 +15,15 @@ add_executable(replay-server
     replay-server.cc
 )
 
-target_link_libraries(replay-server PUBLIC lib-replay-core swoc++::swoc++ yaml-cpp Threads::Threads OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(replay-server PUBLIC replay-core swoc++::swoc++ yaml-cpp Threads::Threads OpenSSL::SSL OpenSSL::Crypto)
 
+install(TARGETS replay-server RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(TARGETS replay-server
     EXPORT replay-server-config
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 install(EXPORT replay-server-config
-    NAMESPACE replay-serverl::
+    NAMESPACE replay-server::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/replay-server
     )
 export(TARGETS replay-server FILE replay-server-config.cmake)

--- a/local/src/server/replay-server.cc
+++ b/local/src/server/replay-server.cc
@@ -34,8 +34,8 @@
 #include "yaml-cpp/yaml.h"
 
 using swoc::BufferWriter;
-using swoc::TextView;
 using swoc::Errata;
+using swoc::TextView;
 
 void TF_Serve(std::thread *t);
 
@@ -109,13 +109,17 @@ void ServerReplayFileHandler::reset() {
 
 swoc::Errata ServerReplayFileHandler::txn_open(YAML::Node const &node) {
   Errata errata;
-  if (! node[YAML_PROXY_REQ_KEY]) {
-    errata.error(R"(Transaction node at {} does not have a proxy request [{}].)", node.Mark(), YAML_PROXY_REQ_KEY);
+  if (!node[YAML_PROXY_REQ_KEY]) {
+    errata.error(
+        R"(Transaction node at {} does not have a proxy request [{}].)",
+        node.Mark(), YAML_PROXY_REQ_KEY);
   }
-  if (! node[YAML_SERVER_RSP_KEY]) {
-    errata.error(R"(Transaction node at {} does not have a server response [{}].)", node.Mark(), YAML_SERVER_RSP_KEY);
+  if (!node[YAML_SERVER_RSP_KEY]) {
+    errata.error(
+        R"(Transaction node at {} does not have a server response [{}].)",
+        node.Mark(), YAML_SERVER_RSP_KEY);
   }
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     return std::move(errata);
   }
   LoadMutex.lock();
@@ -388,7 +392,8 @@ void Engine::command_run() {
   }
   HttpHeader::set_max_content_length(max_content_length);
 
-  std::cout << "Ready with " << Transactions.size() << " transactions." << std::endl;
+  std::cout << "Ready with " << Transactions.size() << " transactions."
+            << std::endl;
 
   for (auto &server_addr : server_addrs) {
     // Set up listen port.

--- a/local/src/server/replay-server.cc
+++ b/local/src/server/replay-server.cc
@@ -298,7 +298,7 @@ void Engine::command_run() {
     errata.error(
         R"("run" command requires a directory path as an argument.)");
   }
-  
+
   if (server_addr_arg) {
     if (server_addr_arg.size() == 1) {
       errata = parse_ips(server_addr_arg[0], server_addrs);
@@ -345,7 +345,7 @@ void Engine::command_run() {
           R"(--listen-https option must have a single value, the listen address and port.)");
     }
   }
-  
+
   if (!errata.is_ok()) {
     return;
   }
@@ -379,7 +379,7 @@ void Engine::command_run() {
 
   std::cout << "Ready" << std::endl;
 
-  for (auto &server_addr: server_addrs) {
+  for (auto &server_addr : server_addrs) {
     // Set up listen port.
     if (server_addr.is_valid()) {
       errata = do_listen(server_addr, false);
@@ -388,7 +388,7 @@ void Engine::command_run() {
       return;
     }
   }
-  for (auto &server_addr_https: server_addrs_https) {
+  for (auto &server_addr_https : server_addrs_https) {
     if (server_addr_https.is_valid()) {
       errata = do_listen(server_addr_https, true);
     }
@@ -410,9 +410,12 @@ int main(int argc, const char *argv[]) {
   engine.parser
       .add_command("run", "run <dir>: the replay server using data in <dir>",
                    "", 1, [&]() -> void { engine.command_run(); })
-      .add_option("--listen", "", "Listen address and port. Can be a comma separated list.", "", 1, "")
-      .add_option("--listen-https", "", "Listen TLS address and port. Can be a comma separated list.", "", 1,
-                  "")
+      .add_option("--listen", "",
+                  "Listen address and port. Can be a comma separated list.", "",
+                  1, "")
+      .add_option("--listen-https", "",
+                  "Listen TLS address and port. Can be a comma separated list.",
+                  "", 1, "")
       .add_option("--cert", "", "Specify certificate file", "", 1, "");
 
   // parse the arguments

--- a/local/src/server/replay-server.cc
+++ b/local/src/server/replay-server.cc
@@ -306,12 +306,17 @@ void Engine::command_run() {
   auto server_addr_arg{arguments.get("listen")};
   auto server_addr_https_arg{arguments.get("listen-https")};
   auto cert_arg{arguments.get("cert")};
+  auto key_arg{arguments.get("key")};
 
   swoc::LocalBufferWriter<1024> w;
 
   if (args.size() < 1) {
     errata.error(
         R"("run" command requires a directory path as an argument.)");
+  }
+
+  if (key_arg) {
+    HttpHeader::_key_format = key_arg[0];
   }
 
   if (server_addr_arg) {
@@ -432,6 +437,7 @@ int main(int argc, const char *argv[]) {
       .add_option("--listen-https", "",
                   "Listen TLS address and port. Can be a comma separated list.",
                   "", 1, "")
+      .add_option("--key", "-k", "Transaction key format", "", 1, "")
       .add_option("--cert", "", "Specify certificate file", "", 1, "");
 
   // parse the arguments


### PR DESCRIPTION
*  Allow YAML format for replay files.
*  Server, client now only check for their required fields so they can be used independently.
*  Allow loading of a single file, not an entire directory.
*  Specify the transaction identifying key on the command line.